### PR TITLE
fix(yasnippet-lean.el): drop custom keybindings

### DIFF
--- a/yasnippet-lean.el
+++ b/yasnippet-lean.el
@@ -64,10 +64,6 @@ See Info node `(elisp)Customization Types'."
 (eval-after-load 'yasnippet
    '(yasnippet-lean-initialize))
 
-(define-key lean-mode-map "\C-s&\C-s" 'yas-insert-snippet)
-(define-key lean-mode-map "\C-s&\C-n" 'yas-new-snippet)
-(define-key lean-mode-map "\C-s&\C-v" 'yas-visit-snippet-file)
-
 (provide 'yasnippet-lean)
 
 ;;; yasnippet-lean.el ends here


### PR DESCRIPTION
I have 3 reasons to remove them:

* yasnippet has other keybindings for these functions and I assume that packages should not change keybindings of other packages;
* these bindings conflict with the default "search" (`C-s`) key binding in Emacs;
* it's easy to add these keybindings back in `~/.emacs.d/init.el`.