### PR TITLE
chore(license-boilerplate): user full name, commas

### DIFF
--- a/snippets/lean-mode/license-boilerplate
+++ b/snippets/lean-mode/license-boilerplate
@@ -3,9 +3,7 @@
 # key: license
 # --
 /-
-Copyright (c) `(format-time-string "%Y")` $1. All rights reserved.
+Copyright (c) `(format-time-string "%Y")` ${1:`user-full-name`}. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Author(s): $1 $2
-
-${3:put description here }
+Author${2:$(if (string= "" yas-text) "" "s")}: $1${2:$(if (string= "" yas-text) "" ", ")}${2:other}
 -/


### PR DESCRIPTION
* Use user full name as author name by default;
* automatically add "s" to "Author" and ", " if there are other authors